### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.py linguist-detectable=true
+*.html linguist-detectable=false
+*.htm linguist-detectable=false


### PR DESCRIPTION
Manually specified the primary language used in the repository (`.py`) removing `.html` and `.htm`.